### PR TITLE
トップページの日付の形式を、YYYY/MM/DD HH:mm 形式へ変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "helmet": "^3.8.2",
     "http-errors": "~1.6.2",
     "jquery": "3.4.1",
+    "moment-timezone": "0.5.0",
     "morgan": "~1.9.0",
     "passport": "^0.3.2",
     "passport-github2": "^0.1.9",

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const Schedule = require('../models/schedule');
+const moment = require('moment-timezone');
 
 /* GET home page. */
 router.get('/', (req, res, next) => {
@@ -13,6 +14,9 @@ router.get('/', (req, res, next) => {
       },
       order: [['updatedAt', 'DESC']]
     }).then((schedules) => {
+      schedules.forEach((schedule) => {
+        schedule.formattedUpdatedAt = moment(schedule.updatedAt).tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm');
+      });
       res.render('index', {
         title: title,
         user: req.user,

--- a/views/index.pug
+++ b/views/index.pug
@@ -18,4 +18,4 @@ block content
           tr
             td
               a(href=`/schedules/${schedule.scheduleId}`) #{schedule.scheduleName}
-            td #{schedule.updatedAt}
+            td #{schedule.formattedUpdatedAt}


### PR DESCRIPTION
マージは不要です